### PR TITLE
Start using keyword arguments for all `new` calls

### DIFF
--- a/accessing_attributes/bmbm.rb
+++ b/accessing_attributes/bmbm.rb
@@ -5,12 +5,12 @@ keys = 1000.times.map { |i| "key#{i}".to_sym }
 values = 1000.times.map { |i| "value#{i}" }
 keys_and_values = Hash[keys.zip(values)]
 
-BigDataS = Struct.new(*keys)
+BigDataS = Struct.new(*keys, keyword_init: true)
 BigDataD = Data.define(*keys)
 
-struct_object = BigDataS.new(*values)
-data_object = BigDataD.new(*values)
-opens_struct_object = OpenStruct.new(keys_and_values)
+struct_object = BigDataS.new(**keys_and_values)
+data_object = BigDataD.new(**keys_and_values)
+opens_struct_object = OpenStruct.new(**keys_and_values)
 
 puts "Accessing attributes - bmbm test"
 

--- a/accessing_attributes/ips.rb
+++ b/accessing_attributes/ips.rb
@@ -5,12 +5,12 @@ keys = 1000.times.map { |i| "key#{i}".to_sym }
 values = 1000.times.map { |i| "value#{i}" }
 keys_and_values = Hash[keys.zip(values)]
 
-BigDataS = Struct.new(*keys)
+BigDataS = Struct.new(*keys, keyword_init: true)
 BigDataD = Data.define(*keys)
 
-struct_object = BigDataS.new(*values)
-data_object = BigDataD.new(*values)
-opens_struct_object = OpenStruct.new(keys_and_values)
+struct_object = BigDataS.new(**keys_and_values)
+data_object = BigDataD.new(**keys_and_values)
+opens_struct_object = OpenStruct.new(**keys_and_values)
 
 puts "Accessing attributes - ips test"
 

--- a/creating_values/bmbm.rb
+++ b/creating_values/bmbm.rb
@@ -5,21 +5,21 @@ keys = 1000.times.map { |i| "key#{i}".to_sym }
 values = 1000.times.map { |i| "value#{i}" }
 keys_and_values = Hash[keys.zip(values)]
 
-DataStruct = Struct.new(*keys)
+DataStruct = Struct.new(*keys, keyword_init: true)
 DataDefine = Data.define(*keys)
 
 puts "Creating a new object - Benchmark with bmbm"
 
 Benchmark.bmbm do |x|
   x.report("Struct.new") do
-    DataStruct.new(*values)
+    DataStruct.new(**keys_and_values)
   end
 
   x.report("Data.define") do
-    DataDefine.new(*values)
+    DataDefine.new(**keys_and_values)
   end
 
   x.report("OpenStruct.new") do
-    OpenStruct.new(keys_and_values)
+    OpenStruct.new(**keys_and_values)
   end
 end

--- a/creating_values/ips.rb
+++ b/creating_values/ips.rb
@@ -5,22 +5,22 @@ keys = 1000.times.map { |i| "key#{i}".to_sym }
 values = 1000.times.map { |i| "value#{i}" }
 keys_and_values = Hash[keys.zip(values)]
 
-DataStruct = Struct.new(*keys)
+DataStruct = Struct.new(*keys, keyword_init: true)
 DataDefine = Data.define(*keys)
 
 puts "Creating a new object - Benchmark with ips"
 
 Benchmark.ips do |x|
   x.report("Struct.new") do
-    DataStruct.new(*values)
+    DataStruct.new(**keys_and_values)
   end
 
   x.report("Data.define") do
-    DataDefine.new(*values)
+    DataDefine.new(**keys_and_values)
   end
 
   x.report("OpenStruct.new") do
-    OpenStruct.new(keys_and_values)
+    OpenStruct.new(**keys_and_values)
   end
   x.compare!
 end

--- a/creating_values/memory.rb
+++ b/creating_values/memory.rb
@@ -4,22 +4,22 @@ keys = 1000.times.map { |i| "key#{i}".to_sym }
 values = 1000.times.map { |i| "value#{i}" }
 keys_and_values = Hash[keys.zip(values)]
 
-DataStruct = Struct.new(*keys)
+DataStruct = Struct.new(*keys, keyword_init: true)
 DataDefine = Data.define(*keys)
 
 puts "Creating a new object - Benchmark with ips"
 
 Benchmark.memory do |x|
   x.report("Struct.new") do
-    DataStruct.new(*values)
+    DataStruct.new(**keys_and_values)
   end
 
   x.report("Data.define") do
-    DataDefine.new(*values)
+    DataDefine.new(**keys_and_values)
   end
 
   x.report("OpenStruct.new") do
-    OpenStruct.new(keys_and_values)
+    OpenStruct.new(**keys_and_values)
   end
 
   x.compare!


### PR DESCRIPTION
IPS:
```
$ bundle exec ruby creating_values/ips.rb
Creating a new object - Benchmark with ips
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
          Struct.new     3.942k i/100ms
         Data.define     4.065k i/100ms
      OpenStruct.new    44.000 i/100ms
Calculating -------------------------------------
          Struct.new     39.020k (± 3.1%) i/s -    197.100k in   5.056615s
         Data.define     40.334k (± 5.0%) i/s -    203.250k in   5.053979s
      OpenStruct.new    406.094 (± 7.1%) i/s -      2.024k in   5.011065s

Comparison:
         Data.define:    40334.4 i/s
          Struct.new:    39020.4 i/s - same-ish: difference falls within error
      OpenStruct.new:      406.1 i/s - 99.32x  slower
```
Memory:
```
$ bundle exec ruby creating_values/memory.rb
Creating a new object - Benchmark with ips
Calculating -------------------------------------
          Struct.new    36.792k memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
         Data.define    36.792k memsize (     0.000  retained)
                         2.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
      OpenStruct.new   848.728k memsize (     0.000  retained)
                         8.005k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)

Comparison:
          Struct.new:      36792 allocated
         Data.define:      36792 allocated - same
      OpenStruct.new:     848728 allocated - 23.07x more
```